### PR TITLE
refactor: ssh connections

### DIFF
--- a/examples/digitalocean/main.tf
+++ b/examples/digitalocean/main.tf
@@ -34,10 +34,12 @@ run_list 'chef-client::default'
 }
 
 module "provision" {
-  source              = "../.."
-  host                = digitalocean_droplet.chef-node.ipv4_address
+  source = "../.."
+  connection = {
+    host        = digitalocean_droplet.chef-node.ipv4_address
+    private_key = tls_private_key.default.private_key_pem
+  }
   policyfile          = local_file.policyfile.filename
-  ssh_key             = tls_private_key.default.private_key_pem
   chef_client_version = 16.6
 }
 

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ locals {
 # connection blocks
 locals {
   _private_key_is_path         = try(fileexists(pathexpand(var.connection.private_key)), false)
-  _bastion_private_key_is_path = try(fileexists(pathexpand(var.connection.bvation_private_key)), false)
+  _bastion_private_key_is_path = try(fileexists(pathexpand(var.connection.bastion_private_key)), false)
   private_key                  = local._private_key_is_path ? file(pathexpand(var.connection.private_key)) : var.connection.private_key
   bastion_private_key          = local._bastion_private_key_is_path ? file(pathexpand(var.connection.bastion_private_key)) : var.connection.bastion_private_key
 

--- a/main.tf
+++ b/main.tf
@@ -11,13 +11,13 @@ locals {
   _install_chef_script_name        = "installchef.sh"
   _install_chef_script_source      = format("%s/scripts/%s", path.module, local._install_chef_script_name)
   _install_chef_script_destination = format("%s/%s", local.target_install_dir, local._install_chef_script_name)
-  chef_client_version         = var.chef_client_version
-  _archive_supplied           = var.policyfile_archive == "" ? false : true
-  _archive_supplied_is_file   = try(local._archive_supplied, fileexists(pathexpand(var.policyfile_archive)), false)
-  _archive_supplied_is_dir    = local._archive_supplied && (local._archive_supplied_is_file != true) ? true : false
-  _archive_supplied_dirname   = local._archive_supplied_is_file ? format("%s/", dirname(pathexpand(var.policyfile_archive))) : format("%s/", pathexpand(var.policyfile_archive))
-  _archive_selector           = try(element(sort(fileset(local._archive_supplied_dirname, format("{%s}**.tgz", local.policy_name))), 0), "NO_ARCHIVE_FOUND_FOR_POLICY")
-  supplied_policyfile_archive = local._archive_supplied_is_file ? pathexpand(var.policyfile_archive) : local._archive_supplied_is_dir ? local._archive_selector : "💩"
+  chef_client_version              = var.chef_client_version
+  _archive_supplied                = var.policyfile_archive == "" ? false : true
+  _archive_supplied_is_file        = try(local._archive_supplied, fileexists(pathexpand(var.policyfile_archive)), false)
+  _archive_supplied_is_dir         = local._archive_supplied && (local._archive_supplied_is_file != true) ? true : false
+  _archive_supplied_dirname        = local._archive_supplied_is_file ? format("%s/", dirname(pathexpand(var.policyfile_archive))) : format("%s/", pathexpand(var.policyfile_archive))
+  _archive_selector                = try(element(sort(fileset(local._archive_supplied_dirname, format("{%s}**.tgz", local.policy_name))), 0), "NO_ARCHIVE_FOUND_FOR_POLICY")
+  supplied_policyfile_archive      = local._archive_supplied_is_file ? pathexpand(var.policyfile_archive) : local._archive_supplied_is_dir ? local._archive_selector : "💩"
   # if the policyfile archive supplied is a directory, add a trailing slash
   supplied_policyfile_archive_basename = format("%s", basename(trimsuffix(local.supplied_policyfile_archive, "/")))
   chef_client_log_level                = var.chef_client_log_level
@@ -29,37 +29,34 @@ locals {
 }
 
 
-# connection
+# connection blocks
 locals {
-  # The connection block docs say that
-  # the private key takes precendence over
-  # the password if the private key is provided
-  _private_key_is_path        = try(fileexists(pathexpand(var.connection.private_key)), false)
-  _bastion_private_key_is_path        = try(fileexists(pathexpand(var.connection.bvation_private_key)), false)
-  private_key                 = local._private_key_is_path ? file(pathexpand(var.connection.private_key)) : var.connection.private_key
-  bastion_private_key                 = local._bastion_private_key_is_path ? file(pathexpand(var.connection.bastion_private_key)) : var.connection.bastion_private_key
+  _private_key_is_path         = try(fileexists(pathexpand(var.connection.private_key)), false)
+  _bastion_private_key_is_path = try(fileexists(pathexpand(var.connection.bvation_private_key)), false)
+  private_key                  = local._private_key_is_path ? file(pathexpand(var.connection.private_key)) : var.connection.private_key
+  bastion_private_key          = local._bastion_private_key_is_path ? file(pathexpand(var.connection.bastion_private_key)) : var.connection.bastion_private_key
 
   connection = {
-      type                = "ssh"
-      user                = var.connection.user
-      password            = var.connection.password
-      host                = var.connection.host
-      port                = var.connection.port
-      timeout             = var.connection.timeout
-      script_path         = var.connection.script_path
-      private_key         = local.private_key
-      certificate         = var.connection.certificate
-      agent               = var.connection.agent
-      agent_identity      = var.connection.agent_identity
-      host_key            = var.connection.host_key
-      bastion_host        = var.connection.bastion_host
-      bastion_host_key    = var.connection.bastion_host_key
-      bastion_port        = var.connection.bastion_port
-      bastion_user        = var.connection.bastion_user
-      bastion_password    = var.connection.bastion_password
-      bastion_private_key = local.bastion_private_key
-      bastion_certificate = var.connection.bastion_certificate
-    }
+    type                = "ssh"
+    user                = var.connection.user
+    password            = var.connection.password
+    host                = var.connection.host
+    port                = var.connection.port
+    timeout             = var.connection.timeout
+    script_path         = var.connection.script_path
+    private_key         = local.private_key
+    certificate         = var.connection.certificate
+    agent               = var.connection.agent
+    agent_identity      = var.connection.agent_identity
+    host_key            = var.connection.host_key
+    bastion_host        = var.connection.bastion_host
+    bastion_host_key    = var.connection.bastion_host_key
+    bastion_port        = var.connection.bastion_port
+    bastion_user        = var.connection.bastion_user
+    bastion_password    = var.connection.bastion_password
+    bastion_private_key = local.bastion_private_key
+    bastion_certificate = var.connection.bastion_certificate
+  }
 }
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,5 +11,5 @@ output "destination_directory" {
 }
 
 output "ssh_command" {
-  value = format("ssh %s@%s %s", local.ssh_user, local.host, (local._private_key_is_path ? format("-i %s", var.ssh_key) : ""))
+  value = format("ssh %s@%s %s", coalesce(local.connection.user, "root"), local.connection.host, (local._private_key_is_path ? format("-i %s", local.connection.private_key) : "💩"))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,36 +52,6 @@ variable "policyfile_archive" {
   default     = ""
 }
 
-
-variable "host" {
-  type        = string
-  description = "Address of host (for ssh purposes)"
-}
-
-variable "ssh_key" {
-  type        = string
-  description = "Private key content, or local path to your private ssh key."
-  default     = "~/.ssh/id_rsa"
-}
-
-variable "ssh_user" {
-  type        = string
-  description = "SSH User Name"
-  default     = "root"
-}
-
-variable "ssh_port" {
-  type        = number
-  description = "SSH Port"
-  default     = 22
-}
-
-variable "ssh_password" {
-  type        = string
-  description = "SSH Password, if applicable"
-  default     = ""
-}
-
 variable "skip" {
   type        = bool
   description = "To skip chef provisiong, set this to true"
@@ -98,4 +68,29 @@ variable "skip_data_bags_push" {
   type        = bool
   description = "To force skip pushing the data_bags, set this to true. This is a temporary fix until we have code in place to determine whether the archive has changed since last push/apply."
   default     = false
+}
+
+variable "connection" {
+  type = object({
+    user                = optional(string)
+    password            = optional(string)
+    host                = string
+    port                = optional(number)
+    timeout             = optional(string)
+    script_path         = optional(string)
+    private_key         = optional(string)
+    certificate         = optional(string)
+    agent               = optional(bool)
+    agent_identity      = optional(string)
+    host_key            = optional(string)
+    bastion_host        = optional(string)
+    bastion_host_key    = optional(string)
+    bastion_port        = optional(number)
+    bastion_user        = optional(string)
+    bastion_password    = optional(string)
+    bastion_private_key = optional(string)
+    bastion_certificate = optional(string)
+  })
+
+  description = "https://www.terraform.io/docs/language/resources/provisioners/connection.html"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,10 @@ variable "skip_data_bags_push" {
   default     = false
 }
 
+terraform {
+  experiments = [module_variable_optional_attrs]
+}
+
 variable "connection" {
   type = object({
     user                = optional(string)


### PR DESCRIPTION
This is a breaking change. The following variables are now deprecated in favor of using the `connection` object variable.

* `host` is now `connection.host` (this is the only required key/value pair)
* `ssh_password` is now `connection.password`
* `ssh_port` is now `connection.port`
* `ssh_user` is now `connection.user`
* `ssh_key` is now `connection.private_key`

In addition to this, all connection attributes are exposed/available, including `bastion_host`, `agent` and other `bastion...` related connection settings.

See https://www.terraform.io/docs/language/resources/provisioners/connection.html for more info. (Especially, Argument Reference)